### PR TITLE
fix: 有 dn 时磁力复制地址会 undefined

### DIFF
--- a/coffee/popup.coffee
+++ b/coffee/popup.coffee
@@ -98,6 +98,7 @@ dealMagnet = (linkarr = [])->
       name = l.name
       link = l.link
     else
+      link = l # 傻叉了，只顾 name 忘了最重要的 link
       name_regex = /dn=(.+?)&/
       try
         name = name_regex.exec(l)[1]

--- a/popup.js
+++ b/popup.js
@@ -123,6 +123,7 @@
         name = l.name;
         link = l.link;
       } else {
+        link = l; // 傻叉了，只顾 name 忘了最重要的 link
         name_regex = /dn=(.+?)&/;
         try {
           name = name_regex.exec(l)[1];


### PR DESCRIPTION
有 dn 时 link 没有赋值，只顾 name 了，傻叉了

对 http://www.zimuxia.cn/portfolio/%E5%88%87%E5%B0%94%E8%AF%BA%E8%B4%9D%E5%88%A9 测试成功