### PR TITLE
Fix/magnet link gone if dn duplicated

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -7,13 +7,14 @@ var magnet_result = [];
 
 function gen_magnet_result() {
   // 原逻辑：磁力链有 dn 时，直接返回磁力链，popup.js 去解析文件名
-  var m_result =  document.body.innerHTML.match(magnet_regex) || [];
+  var m_result =  document.body.innerHTML.match(magnet_regex)
+  m_result = m_result ? m_result.filter( onlyUnique ) : []
   if (m_result && m_result[0] && m_result[0].match(magnet_name_regex)) {
     return m_result;
   }
   // 磁力链没 dn 时，用磁力链所在超链接 text 作为文件名
   m_result = [];
-  var magnet_elements = $("a").filter(function() {return this.href.match(magnet_regex);}) || [];
+  var magnet_elements = $("a").filter(function() {return this.href.match(magnet_regex) && onlyUnique;}) || [];
   for (var i = 0; i < magnet_elements.length; i++) {
     name = magnet_elements[i].text;
     var previous_element = m_result[i - 1]
@@ -24,13 +25,23 @@ function gen_magnet_result() {
     }
     m_result.push({link: current_link, name: name});
   }
-  console.log(m_result[0]);
   return m_result;
+}
+
+function gen_ed2k_result() {
+  ed2k_result = document.body.innerHTML.match(regex);
+  ed2k_result = ed2k_result ? ed2k_result.filter( onlyUnique ) : [];
+  return ed2k_result;
+}
+
+// 去重复
+function onlyUnique(value, index, self) {
+  return self.indexOf(value) === index;
 }
 
 function init() {
   if (regex.test(document.body.innerHTML) || magnet_regex.test(document.body.innerHTML)) {
-    ed2k_result = document.body.innerHTML.match(regex) || [];
+    ed2k_result = gen_ed2k_result();
     magnet_result = gen_magnet_result();
     result = {ed2k_result: ed2k_result, magnet_result: magnet_result};
 
@@ -43,7 +54,7 @@ function onRequest(request,sender,sendResponse){
     if(result){
       sendResponse({result:result});
     }else{
-      ed2k_result = document.body.innerHTML.match(regex) || [];
+      ed2k_result = gen_ed2k_result();
       magnet_result = gen_magnet_result();
       result = {ed2k_result: ed2k_result, magnet_result: magnet_result};
 

--- a/popup.js
+++ b/popup.js
@@ -127,6 +127,9 @@
         name_regex = /dn=(.+?)&/;
         try {
           name = name_regex.exec(l)[1];
+          if (re[name]) { // dn 重复了，会导致结果被同名链接覆盖
+            name = `${name}${count + 1}`
+          }
         } catch (error1) {
           error = error1;
           name = l; // 解析失败也显示磁力链，不然没法复制


### PR DESCRIPTION
修复 dn 重复时，同名链接被覆盖 

对 https://www.mp4vod.com/detail/30655.html
及 https://www.mp4vod.com/detail/30634.html
测试成功

另外，做了点优化，对有效链接做去重处理