### PR TITLE
improvement: 将相同 xt 的文件视为同一个文件

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -10,7 +10,14 @@ function gen_magnet_result() {
   var m_result =  document.body.innerHTML.match(magnet_regex)
   m_result = m_result ? m_result.filter( onlyUnique ) : []
   if (m_result && m_result[0] && m_result[0].match(magnet_name_regex)) {
-    return m_result;
+    var xt_and_magnent = {};
+    for (var i = 0; i < m_result.length; i++) {
+      // 相同 xt 视为同一个文件
+      var magnet = m_result[i]
+      var xt = magnet.split('&')[0]
+      xt_and_magnent[xt] = magnet
+    }
+    return Object.values(xt_and_magnent);
   }
   // 磁力链没 dn 时，用磁力链所在超链接 text 作为文件名
   m_result = [];


### PR DESCRIPTION
有些磁力链正则匹配的确是不同的字符串，但 xt 完全相同，所以复制时会多出一份。

其实不影响下载的。例如这 20 个链接（实质上是 10 个文件）复制到 115 下载，会得到 10 个文件。
 
已合并相同 xt 的链接。对 https://www.mp4so.com/detail/30499.html 测试成功

Resolve #15 